### PR TITLE
#3 - Feign - Interceptor 구현

### DIFF
--- a/feign/build.gradle
+++ b/feign/build.gradle
@@ -23,6 +23,7 @@ ext {
      * */
     // Feign
     set('springCloudVersion', '2021.0.8')
+    set('commonsLangVersion', '3.12.0')
 }
 
 dependencyManagement {
@@ -39,6 +40,10 @@ dependencies {
 
     // Feign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // for 'StringUtils'  request body (json ?) -> String 변환
+    // https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
+    implementation "org.apache.commons:commons-lang3:${commonsLangVersion}"
 }
 
 tasks.named('bootBuildImage') {

--- a/feign/src/main/java/dev/be/feign/controller/DemoController.java
+++ b/feign/src/main/java/dev/be/feign/controller/DemoController.java
@@ -15,4 +15,9 @@ public class DemoController {
     public String getController() {
         return service.get();
     }
+
+    @GetMapping("/post")
+    public String postController() {
+        return service.post();
+    }
 }

--- a/feign/src/main/java/dev/be/feign/controller/TargetController.java
+++ b/feign/src/main/java/dev/be/feign/controller/TargetController.java
@@ -1,11 +1,7 @@
 package dev.be.feign.controller;
 
 import dev.be.feign.common.dto.BaseResponseInfo;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/target_server")
@@ -23,6 +19,14 @@ public class TargetController {
                 .name(name)
                 .age(age)
                 .build();
+    }
+
+    @PostMapping("/post")
+    public BaseResponseInfo demoPost(
+            @RequestHeader("CustomHeaderName") String header,
+            @RequestBody BaseResponseInfo body
+    ) {
+        return body;
     }
 
 }

--- a/feign/src/main/java/dev/be/feign/feign/client/DemoFeignClient.java
+++ b/feign/src/main/java/dev/be/feign/feign/client/DemoFeignClient.java
@@ -1,12 +1,11 @@
 package dev.be.feign.feign.client;
 
+import dev.be.feign.common.dto.BaseRequestInfo;
 import dev.be.feign.common.dto.BaseResponseInfo;
 import dev.be.feign.feign.config.DemoFeignConfig;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 @FeignClient(
         name = "demo-client", // 해당 interface 을 가리키는 Key
@@ -22,4 +21,9 @@ public interface DemoFeignClient {
             @RequestParam("age") Long age
             );
 
+    @PostMapping("/post")
+    ResponseEntity<BaseResponseInfo> callPost(
+            @RequestHeader("CustomHeaderName") String customHeader,
+            @RequestBody BaseRequestInfo baseRequestInfo
+            );
 }

--- a/feign/src/main/java/dev/be/feign/feign/config/DemoFeignConfig.java
+++ b/feign/src/main/java/dev/be/feign/feign/config/DemoFeignConfig.java
@@ -1,7 +1,14 @@
 package dev.be.feign.feign.config;
 
+import dev.be.feign.feign.interceptor.DemoFeignInterceptor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class DemoFeignConfig {
+
+    @Bean
+    public DemoFeignInterceptor feignInterceptor() {
+        return DemoFeignInterceptor.of();
+    }
 }

--- a/feign/src/main/java/dev/be/feign/feign/interceptor/DemoFeignInterceptor.java
+++ b/feign/src/main/java/dev/be/feign/feign/interceptor/DemoFeignInterceptor.java
@@ -1,0 +1,35 @@
+package dev.be.feign.feign.interceptor;
+
+import feign.Request;
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+
+
+@Slf4j
+@RequiredArgsConstructor(staticName = "of")
+public class DemoFeignInterceptor implements RequestInterceptor {
+
+    @Override
+    public void apply(RequestTemplate template) {
+
+        // Get 요청일 경우
+        if(template.method() == Request.HttpMethod.GET.name()) {
+            log.info("[GET] [DemoFeignInterceptor] queries : " + template.queries());
+            return;
+        }
+
+        // Post 요청일 경우
+        String encodedReqeustBody = StringUtils.toEncodedString(template.body(), StandardCharsets.UTF_8);
+        log.info("[POST] [DemoFeignInterceptor] requestBody : " + encodedReqeustBody);
+
+        // 추가적으로 추후 필요한 logic 추가 (내부 값 mapping 하여 String 으로 풀기 위해서)
+
+        String convertReqeustBody = encodedReqeustBody;
+        template.body(convertReqeustBody);
+    }
+}

--- a/feign/src/main/java/dev/be/feign/service/DemoService.java
+++ b/feign/src/main/java/dev/be/feign/service/DemoService.java
@@ -1,5 +1,6 @@
 package dev.be.feign.service;
 
+import dev.be.feign.common.dto.BaseRequestInfo;
 import dev.be.feign.common.dto.BaseResponseInfo;
 import dev.be.feign.feign.client.DemoFeignClient;
 import lombok.RequiredArgsConstructor;
@@ -28,4 +29,22 @@ public class DemoService {
         return "Success Fiegn";
     }
 
+    public String post() {
+        BaseRequestInfo baseRequestInfo = BaseRequestInfo
+                .builder()
+                .name("customName")
+                .age(2L)
+                .build();
+
+        ResponseEntity<BaseResponseInfo> response = demoFeignClient.callPost(
+                "CustomHeader",
+                baseRequestInfo
+        );
+
+        log.info("Name : " + response.getBody().getName());
+        log.info("Age : " + response.getBody().getAge());
+        log.info("Header : " + response.getHeaders());
+
+        return "Success Fiegn POST";
+    }
 }


### PR DESCRIPTION
각 RESTful 요청 내용을 각각 모두 다르겠지만,  최종 요청이 나가기 전 공통적으로 반영되는 것들이 있을 수 있다. (ex. 동일한 요청 구조로 변경, 동일 인증 헤더 반영, logging 추가 등) 이런 logic 처리를 중앙 집중식으로 관리하기 위해  요청이 나가기 전 intercepting 이 가능하다.

DemoFeignInterceptor
 - RequestInterceptor 를 상속한 class 구현
 - 특정 요청에 대해  (ex. GET  & 특정 name) Logic 을 구현.
 - reqeustBody -> String 변환을 위해  Build.gradle 에 StringUtil 추가.

DemoFeignConfig
 - interceptor 기능을 사용하기 위해서 구성한 FeginInterceptor 를  Bean method 를 생성하기 위해  추가

DemoController / TragetController / DemoService / DemoFeiginClient
 - 추가 post & 관련 interceptor  추가를 위한 method 추가

This closes #3 