### PR TITLE
[P6-2] 09. 실무 스타일로 Feign Client 사용해보기 - ErrorDecode

### DIFF
--- a/feign/src/main/java/dev/be/feign/controller/DemoController.java
+++ b/feign/src/main/java/dev/be/feign/controller/DemoController.java
@@ -20,4 +20,10 @@ public class DemoController {
     public String postController() {
         return service.post();
     }
+
+    @GetMapping("/error")
+    public String errorDecoderController() {
+        return service.errorDecoder();
+    }
+
 }

--- a/feign/src/main/java/dev/be/feign/controller/TargetController.java
+++ b/feign/src/main/java/dev/be/feign/controller/TargetController.java
@@ -1,6 +1,8 @@
 package dev.be.feign.controller;
 
 import dev.be.feign.common.dto.BaseResponseInfo;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,6 +21,8 @@ public class TargetController {
                 .name(name)
                 .age(age)
                 .build();
+
+        // Client method 에서는 BaseResponseInfo 를 ResponseEntity 로 wrapping 해서 받음.
     }
 
     @PostMapping("/post")
@@ -27,6 +31,11 @@ public class TargetController {
             @RequestBody BaseResponseInfo body
     ) {
         return body;
+    }
+
+    @GetMapping("/error")
+    public ResponseEntity<BaseResponseInfo> demoErrorDecoder() {
+        return  ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
     }
 
 }

--- a/feign/src/main/java/dev/be/feign/feign/client/DemoFeignClient.java
+++ b/feign/src/main/java/dev/be/feign/feign/client/DemoFeignClient.java
@@ -26,4 +26,7 @@ public interface DemoFeignClient {
             @RequestHeader("CustomHeaderName") String customHeader,
             @RequestBody BaseRequestInfo baseRequestInfo
             );
+
+    @GetMapping("/error")
+    ResponseEntity<BaseResponseInfo> callErrorDecoder();
 }

--- a/feign/src/main/java/dev/be/feign/feign/config/DemoFeignConfig.java
+++ b/feign/src/main/java/dev/be/feign/feign/config/DemoFeignConfig.java
@@ -1,13 +1,13 @@
 package dev.be.feign.feign.config;
 
+import dev.be.feign.feign.decoder.DemoFeignErrorDecoder;
 import dev.be.feign.feign.interceptor.DemoFeignInterceptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 
 /**
- * `feign` floder 하위 내부에 존재하는 FeignClient 를 위한 설정 조건을
- *  정의하기 위한 config class
+ * `FeignClient 마다 다른 설정을 정의하기 위한 config class
  * */
 @Configuration
 public class DemoFeignConfig {
@@ -15,5 +15,10 @@ public class DemoFeignConfig {
     @Bean
     public DemoFeignInterceptor feignInterceptor() {
         return DemoFeignInterceptor.of();
+    }
+
+    @Bean
+    public DemoFeignErrorDecoder demoErrorDecoder() {
+        return new DemoFeignErrorDecoder();
     }
 }

--- a/feign/src/main/java/dev/be/feign/feign/decoder/DemoFeignErrorDecoder.java
+++ b/feign/src/main/java/dev/be/feign/feign/decoder/DemoFeignErrorDecoder.java
@@ -1,0 +1,25 @@
+package dev.be.feign.feign.decoder;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import org.springframework.http.HttpStatus;
+
+public class DemoFeignErrorDecoder implements ErrorDecoder {
+    private final ErrorDecoder errorDecoder = new Default();
+
+    // decode 메소드는 FeignException 또는 사용자 정의 예외를 반환
+    // 이 메소드에서는 Response 객체를 분석하여 오류의 원인을 파악하고 적절한 예외를 발생시킴.
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        HttpStatus httpStatus = HttpStatus.resolve(response.status());
+
+        // 사용자가 정의한 error 에 대한 응답 처리
+        if (httpStatus == httpStatus.NOT_FOUND) {
+            System.out.println("[DemoFeignErrorDecoder] Http Status = " + httpStatus);
+            throw new RuntimeException(String.format("[RuntimeException] Http Status is %s", httpStatus));
+        }
+
+        // Feign 에서 정의한 기본적인 error decoder 내용을 사용
+        return errorDecoder.decode(methodKey, response);
+    }
+}

--- a/feign/src/main/java/dev/be/feign/service/DemoService.java
+++ b/feign/src/main/java/dev/be/feign/service/DemoService.java
@@ -45,6 +45,12 @@ public class DemoService {
         log.info("Age : " + response.getBody().getAge());
         log.info("Header : " + response.getHeaders());
 
-        return "Success Fiegn POST";
+        return "Success Feign POST";
+    }
+
+    public String errorDecoder() {
+        demoFeignClient.callErrorDecoder();
+
+        return "Feign ERROR";
     }
 }


### PR DESCRIPTION
DemoFeignErrorDecoder
 - `ErrorDecoder` interface 구현 class 로 `decode` method 를 override 한다.
 - 사용자 정의 error 를 구현한 http status 와 이에 대한 log 를 명시
 - 그 외 error 의 경우 feign 에서 제공하는 기본적인 error 에 대한 response 를 사용하도록 함.

 DemoFeignConfig
 - 앞에서 정의한 `DemoFeignErrorDecoder` 를  config method bean 으로 등록
 - 해당 bean 은 각각의 Feign client 마다 다르게 구성될 수 있음을 가정하고, 해당 feign 에 대해서만 적용될 수 있도록 하위 config class 에 적용

DemoFeignClient / DemoService /  DemoController
 - error 발생을 test 할 url 요청 controller - service - client feign 구현

TargetController
 - client 요청에 대해 error 를 발생시켜 반환하는 method 구현
 - 반환 HttpStatus 가 만약 ErrorDecoder 에 사용자 정의 구현 error status 인 경우, 정의된 log 를 출력하고, 그렇지 않으면 기본 feign error  가 적용된다.
 - 추가로 해당 controller 의 다른 method 의 반환 type 이 조금 다른것 을 볼 수 있는데, 기본적으로  feign client 에서는 `ResponseEntity<Object>` 형태를 반환 받는다. 그런다 target controller 에서  `Object` 로만 보내면 자동으로 wrapping  해주는 기능이 지원되기 때문에 달라도 동일하게 동작한다.

This closes #7 